### PR TITLE
Fix for Issue 5:  Cannot find version 5.7.mysql_aurora.2.08.1 for aurora-mysql #5 

### DIFF
--- a/lib/emr-eks-app-stack.ts
+++ b/lib/emr-eks-app-stack.ts
@@ -76,7 +76,7 @@ export class EmrEksAppStack extends cdk.Stack {
     );
     
     const cluster = new DatabaseCluster(this, 'Database', {
-      engine: DatabaseClusterEngine.auroraMysql({ version: AuroraMysqlEngineVersion.VER_2_08_1 }),
+      engine: DatabaseClusterEngine.auroraMysql({ version: AuroraMysqlEngineVersion.VER_2_11_0 }),
       credentials: Credentials.fromSecret(databaseCredentialsSecret),
       defaultDatabaseName: "hivemetastore",
       instanceProps: {

--- a/lib/emr-eks-app-stack.ts
+++ b/lib/emr-eks-app-stack.ts
@@ -76,7 +76,7 @@ export class EmrEksAppStack extends cdk.Stack {
     );
     
     const cluster = new DatabaseCluster(this, 'Database', {
-      engine: DatabaseClusterEngine.auroraMysql({ version: AuroraMysqlEngineVersion.VER_2_11_0 }),
+      engine: DatabaseClusterEngine.auroraMysql({ version: AuroraMysqlEngineVersion.VER_2_10_0 }),
       credentials: Credentials.fromSecret(databaseCredentialsSecret),
       defaultDatabaseName: "hivemetastore",
       instanceProps: {


### PR DESCRIPTION
I have updated the Aurora version to fix the issue with Aurora version `2.08.1` not found error, and thus resulting the `EmrEksAppStack` to Rollback.

Resolves #5 


